### PR TITLE
Add interface to retrieve current version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,6 +43,20 @@ $ gem install reeper
 
 TODO: Usages insruction will follow soon.
 
+
+This gem ships with a CLI tool, to check what's available you can simply run
+the script directly from `exe/reeper`, by default it will display some usages
+instructions.
+
+[source, sh]
+----
+./exe/reeper
+
+Commands:
+  reeper help [COMMAND]  # Describe available commands or one specific command
+  reeper version         # The Reeper Version
+----
+
 == Development
 
 We are following Sandi Metz's Rules for this gem, you can read
@@ -97,4 +111,4 @@ This library was initialially developed by
 https://www.nist.gov/services-resources/software/reeper[NIST], and then forked
 by https://www.ribose.com[Ribose Inc] for futher imporvements, pleast check the
 https://www.nist.gov/services-resources/software/reeper[NIST] for details
-licensing gnd futher usages.
+licensing and futher usages.

--- a/exe/reeper
+++ b/exe/reeper
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+# resolve bin path, ignoring symlinks
+require "pathname"
+bin_file = Pathname.new(__FILE__).realpath
+
+# add self to libpath
+$:.unshift File.expand_path("../../lib", bin_file)
+
+# Fixes https://github.com/rubygems/rubygems/issues/1420
+require "rubygems/specification"
+
+class Gem::Specification
+  def this; self; end
+end
+
+# start up the CLI
+require "reeper"
+Reeper::Cli.start(ARGV)

--- a/lib/reeper.rb
+++ b/lib/reeper.rb
@@ -1,4 +1,5 @@
 require "reeper/version"
+require "reeper/cli"
 
 module Reeper
   class Error < StandardError; end

--- a/lib/reeper/cli.rb
+++ b/lib/reeper/cli.rb
@@ -1,0 +1,21 @@
+require "thor"
+require "reeper/cli/ui"
+
+module Reeper
+  module Cli
+    def self.ui
+      Reeper::Cli::UI
+    end
+
+    def self.start(args)
+      Base.start(args)
+    end
+
+    class Base < Thor
+      desc "version", "The Reeper Version"
+      def version
+        Cli.ui.say("Version #{Reeper::VERSION}")
+      end
+    end
+  end
+end

--- a/lib/reeper/cli/ui.rb
+++ b/lib/reeper/cli/ui.rb
@@ -1,0 +1,24 @@
+require "thor"
+
+module Reeper
+  module Cli
+    class UI < Thor
+      def self.ask(message)
+        new.ask(message)
+      end
+
+      def self.say(message)
+        new.say(message)
+      end
+
+      def self.error(message)
+        new.error(message)
+      end
+
+      def self.run(command)
+        require "open3"
+        Open3.capture3(command)
+      end
+    end
+  end
+end

--- a/reeper.gemspec
+++ b/reeper.gemspec
@@ -20,8 +20,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
-  spec.bindir        = "bin"
+  spec.bindir        = "exe"
   spec.require_paths = ["lib"]
+  spec.executables   = %w[reeper]
+
+  spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.12.2"

--- a/spec/acceptance/version_spec.rb
+++ b/spec/acceptance/version_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+RSpec.describe "Reeper" do
+  describe "version" do
+    it "displays the current verison" do
+      command = %w(version)
+      output = capture_stdout { Reeper::Cli.start(command) }
+
+      expect(output).to include("Version #{Reeper::VERSION}")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,12 @@
 require "bundler/setup"
 require "reeper"
 
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Reeper::ConsoleHelper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,0 +1,29 @@
+module Reeper
+  module ConsoleHelper
+    def capture_stdout(&_block)
+      original_stdout = $stdout
+      $stdout = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stdout = original_stdout
+      end
+
+      fake.string
+    end
+
+    def capture_stderr(&_block)
+      original_stderr = $stderr
+      $stderr = fake = StringIO.new
+
+      begin
+        yield
+      ensure
+        $stderr = original_stderr
+      end
+
+      fake.string
+    end
+  end
+end


### PR DESCRIPTION
This commit setup Thor and other dependency to run as a CLI tool. As an initial step it adds the `reeper version` command, this will return the current version.

This commit also adds some helpful helper, that will be necessary to smoothly test out all of the available interfaces.