### PR TITLE
Update original link to pre-release tag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ https://sourceforge.net/p/reeper/[Sourceforge]. It is forked for
 potential improvements.
 
 The mirrored branch is located at the
-https://github.com/metanorma/reeper/tree/original[`original` branch]
+https://github.com/metanorma/reeper/releases/tag/v0.1[`pre-release` tag]
 
 == Purpose
 


### PR DESCRIPTION
We've created a release tag for the original version, so this commit updates the link in our readme. It should be much more safe, in-case we accidentally delete the original branch.